### PR TITLE
Fix: Safari Dates and Phone Text Overflow 

### DIFF
--- a/.lp2851/project.json
+++ b/.lp2851/project.json
@@ -1,7 +1,7 @@
 {
   "name": "LP2851 GitHub.io",
   "description": "My personal website, built using React and deployed via GitHub Pages.",
-  "startDate": "Jan 2024",
+  "startDate": "2024-01-01",
   "endDate": null,
   "active": true,
   "links": [

--- a/.lp2851/project.json
+++ b/.lp2851/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "lp2851.github.io",
+  "name": "LP2851 GitHub.io",
   "description": "My personal website, built using React and deployed via GitHub Pages.",
   "startDate": "Jan 2024",
   "endDate": null,

--- a/public/data/projects.json
+++ b/public/data/projects.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "lp2851.github.io",
+    "name": "LP2851 GitHub.io",
     "auto": "https://raw.githubusercontent.com/LP2851/LP2851.github.io/refs/heads/main/.lp2851/project.json"
   },
   {

--- a/public/data/projects.json
+++ b/public/data/projects.json
@@ -6,8 +6,8 @@
   {
     "name": "Tool-Assisted Moral and Ethical Simulations",
     "description": "As part of my final year university group project, we developed a framework for studying human morality using AI-driven analysis. Participants engaged in VR simulations of classic moral dilemmas, such as the Trolley Problem, to enhance immersion and data validity. Our system then classified moral decision-making styles using machine learning, identifying patterns and constructing neural networks to categorise users.",
-    "startDate": "Sept 2021",
-    "endDate": "Apr 2022",
+    "startDate": "2021-09-01",
+    "endDate": "2022-04-01",
     "active": false,
     "links": [],
     "technologies": [
@@ -37,8 +37,8 @@
   {
     "name": "Algorithm Demos",
     "description": "A small learning project that provides short demonstrations of sorting and pathfinding algorithms on randomly generated data. This project includes: bubble sort, merge sort, quick sort, depth-first search, breadth-first search, Dijkstra's algorithm and A* search.",
-    "startDate": "Apr 2022",
-    "endDate": "May 2022",
+    "startDate": "2022-04-01",
+    "endDate": "2022-05-01",
     "active": false,
     "links": [
       {

--- a/src/components/image-grid/ImageGrid.tsx
+++ b/src/components/image-grid/ImageGrid.tsx
@@ -1,9 +1,10 @@
 import { memo, useState } from "react";
 import { ImageModal } from "../modal/ImageModal.tsx";
+import { ImageData } from "../../types/ProjectData.ts";
 import "./ImageGrid.css";
 
 interface Props {
-  images: { src: string; alt: string }[];
+  images: ImageData[];
 }
 
 const ImageGridComponent = (props: Props) => {

--- a/src/components/modal/ImageModal.tsx
+++ b/src/components/modal/ImageModal.tsx
@@ -10,9 +10,7 @@ const ImageModalComponent = ({ src, onClose }: Props) => {
   if (!src) return null;
   return (
     <div className="modal" onClick={onClose}>
-      <div className="modal-content">
-        <img src={src} alt="Selected" />
-      </div>
+      <img src={src} alt="Selected" />
     </div>
   );
 };

--- a/src/components/modal/modal.css
+++ b/src/components/modal/modal.css
@@ -11,13 +11,8 @@
   justify-content: center;
 }
 
-.modal-content {
-  max-width: 90%;
-  max-height: 90%;
-}
-
 .modal img {
-  width: 100%;
-  height: auto;
+  max-height: 90vh;
+  max-width: 90vw;
   border-radius: 8px;
 }

--- a/src/components/post/Post.tsx
+++ b/src/components/post/Post.tsx
@@ -2,7 +2,7 @@ import { memo } from "react";
 import { Card } from "../card/Card";
 import { TagsBar } from "../tags-bar/TagsBar";
 import { formattedDate } from "../../helpers/PostData";
-import { PostData } from "../../types/PostData"
+import { PostData } from "../../types/PostData";
 import { PostContent } from "./content/PostContent";
 import "./Post.css";
 

--- a/src/components/post/Post.tsx
+++ b/src/components/post/Post.tsx
@@ -1,9 +1,10 @@
 import { memo } from "react";
 import { Card } from "../card/Card";
 import { TagsBar } from "../tags-bar/TagsBar";
-import { formattedDate, PostData } from "../../helpers/PostData";
-import "./Post.css";
+import { formattedDate } from "../../helpers/PostData";
+import { PostData } from "../../types/PostData"
 import { PostContent } from "./content/PostContent";
+import "./Post.css";
 
 type Props = {
   post: PostData;

--- a/src/containers/projects/Projects.tsx
+++ b/src/containers/projects/Projects.tsx
@@ -2,7 +2,7 @@ import { memo, useEffect, useState } from "react";
 import { PageContainer } from "../../components/page-container/PageContainer";
 import { fetchJsonData } from "../../helpers/DataReader.ts";
 import { Spinner } from "../../components/spinner/Spinner.tsx";
-import { ProjectData } from "../../helpers/ProjectData.ts";
+import { ProjectData } from "../../types/ProjectData.ts";
 import { ProjectCard } from "./project-card/ProjectCard.tsx";
 import { WipMessage } from "../../components/wip-message/WipMessage.tsx";
 

--- a/src/containers/projects/Projects.tsx
+++ b/src/containers/projects/Projects.tsx
@@ -38,7 +38,7 @@ const ProjectsComponent = () => {
   }, []);
 
   return (
-    <PageContainer title="Projects">
+    <PageContainer title="Personal Projects">
       {projects.length !== 0 ? (
         projects.map((p) => <ProjectCard project={p} />)
       ) : (

--- a/src/containers/projects/project-card/ProjectCard.css
+++ b/src/containers/projects/project-card/ProjectCard.css
@@ -40,6 +40,7 @@
 .project-links {
   font-size: medium;
   text-align: left;
+  overflow-wrap: anywhere;
 
   & > h4 {
     margin-top: 0;

--- a/src/containers/projects/project-card/ProjectCard.tsx
+++ b/src/containers/projects/project-card/ProjectCard.tsx
@@ -1,6 +1,6 @@
 import { memo } from "react";
 import { Card } from "../../../components/card/Card.tsx";
-import { ProjectData } from "../../../helpers/ProjectData.ts";
+import { ProjectData } from "../../../types/ProjectData.ts";
 import { TagsBar } from "../../../components/tags-bar/TagsBar.tsx";
 import { BooleanTag } from "../../../components/tags-bar/tag/BooleanTag.tsx";
 import { shortDate } from "../../../helpers/PostData.ts";
@@ -45,14 +45,6 @@ const ProjectCardComponent = ({ project: props }: Props) => {
         )}
 
         <p className="project-description">{props.description}</p>
-
-        {/*{ props.images && props.images.length > 0 &&*/}
-        {/*  <div className="project-images">*/}
-        {/*    { props.images?.map((image) =>*/}
-        {/*      <img src={`${import.meta.env.BASE_URL}${image.src}`} alt={image.alt} />*/}
-        {/*    )}*/}
-        {/*  </div>*/}
-        {/*}*/}
 
         {props.images && props.images.length > 0 && (
           <div className="project-images">

--- a/src/helpers/PostData.ts
+++ b/src/helpers/PostData.ts
@@ -1,20 +1,3 @@
-export type PostData = {
-  title: string;
-  content: Content;
-  tags: string[];
-  date: string;
-};
-
-export enum ContentTypes {
-  DEFAULT = "default",
-}
-
-export type Content = {
-  type: ContentTypes.DEFAULT;
-  data: {
-    textContent?: string;
-  };
-};
 
 export const shortDate = (dateStr: string) => {
   const date = new Date(dateStr);

--- a/src/helpers/PostData.ts
+++ b/src/helpers/PostData.ts
@@ -1,4 +1,3 @@
-
 export const shortDate = (dateStr: string) => {
   const date = new Date(dateStr);
   const monthNames = [

--- a/src/types/PostData.ts
+++ b/src/types/PostData.ts
@@ -1,0 +1,17 @@
+export type PostData = {
+  title: string;
+  content: Content;
+  tags: string[];
+  date: string;
+};
+
+export enum ContentTypes {
+  DEFAULT = "default",
+}
+
+export type Content = {
+  type: ContentTypes.DEFAULT;
+  data: {
+    textContent?: string;
+  };
+};

--- a/src/types/ProjectData.ts
+++ b/src/types/ProjectData.ts
@@ -1,3 +1,14 @@
+
+export type ImageData = {
+  src: string;
+  alt: string;
+};
+
+export type LinkData = {
+  name: string;
+  link: string;
+};
+
 export type ProjectData = {
   auto?: string;
   name: string;
@@ -5,14 +16,8 @@ export type ProjectData = {
   startDate: string;
   endDate?: string;
   active: boolean;
-  links: {
-    name: string;
-    link: string;
-  }[];
+  links: LinkData[];
   technologies: string[];
   keywords: string[];
-  images?: {
-    src: string;
-    alt: string;
-  }[];
+  images?: ImageData[];
 };

--- a/src/types/ProjectData.ts
+++ b/src/types/ProjectData.ts
@@ -1,4 +1,3 @@
-
 export type ImageData = {
   src: string;
   alt: string;


### PR DESCRIPTION
Fixes: 
- Issue on Safari with parsing of dates
- Issue on phones where links would overflow the cards
- Issue where image modal sometimes made images overflow the page
- Rename for `lp2851.github.io` project in data 
- Refactor: move types into separate directory